### PR TITLE
numerically-indexed objects are not converted to Arrays

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,8 +8,8 @@
     <url>https://github.com/jclawson/jackson-dataformat-hocon</url>
 
     <properties>
-        <jackson.core.version>2.3.0</jackson.core.version>
-        <jackson.annotations.version>${jackson.core.version}</jackson.annotations.version>
+        <jackson.core.version>2.4.1.1</jackson.core.version>
+        <jackson.annotations.version>2.4.1</jackson.annotations.version>
         <maven.compiler.source>1.6</maven.compiler.source>
 		<maven.compiler.target>1.6</maven.compiler.target>
     </properties>

--- a/src/main/java/com/jasonclawson/jackson/dataformat/hocon/HoconFactory.java
+++ b/src/main/java/com/jasonclawson/jackson/dataformat/hocon/HoconFactory.java
@@ -390,39 +390,7 @@ public class HoconFactory extends JsonFactory {
     }
 
     @Override
-    @Deprecated
-    protected HoconTreeTraversingParser _createJsonParser(InputStream in, IOContext ctxt)
-        throws IOException, JsonParseException
-    {
-        return _createParser(in, ctxt);
-    }
-
-    @Override
-    @Deprecated
-    protected JsonParser _createJsonParser(Reader r, IOContext ctxt)
-        throws IOException, JsonParseException
-    {
-        return _createParser(r, ctxt);
-    }
-
-    @Override
-    @Deprecated
-    protected HoconTreeTraversingParser _createJsonParser(byte[] data, int offset, int len, IOContext ctxt)
-        throws IOException, JsonParseException
-    {
-        return _createParser(data, offset, len, ctxt);
-    }
-
-    @Override
     protected JsonGenerator _createGenerator(Writer out, IOContext ctxt)
-        throws IOException
-    {
-    	throw new UnsupportedOperationException("Generating HOCON is not supported yet");
-    }
-
-    @Override
-    @Deprecated
-    protected JsonGenerator _createJsonGenerator(Writer out, IOContext ctxt)
         throws IOException
     {
     	throw new UnsupportedOperationException("Generating HOCON is not supported yet");
@@ -435,12 +403,6 @@ public class HoconFactory extends JsonFactory {
     	throw new UnsupportedOperationException("Generating HOCON is not supported yet");
     }
 
-    @Override
-    @Deprecated
-    protected JsonGenerator _createUTF8JsonGenerator(OutputStream out, IOContext ctxt) throws IOException {
-    	throw new UnsupportedOperationException("Generating HOCON is not supported yet");
-    }
-    
     @Override
     protected Writer _createWriter(OutputStream out, JsonEncoding enc, IOContext ctxt) throws IOException
     {

--- a/src/main/java/com/jasonclawson/jackson/dataformat/hocon/HoconTreeTraversingParser.java
+++ b/src/main/java/com/jasonclawson/jackson/dataformat/hocon/HoconTreeTraversingParser.java
@@ -74,15 +74,23 @@ public class HoconTreeTraversingParser extends ParserMinimalBase {
             _nextToken = JsonToken.START_ARRAY;
             _nodeCursor = new HoconNodeCursor.Array(n, null);
         } else if (n.valueType() == ConfigValueType.OBJECT) {
-            _nextToken = JsonToken.START_OBJECT;
-            _nodeCursor = new HoconNodeCursor.Object(n, null);
+            if (HoconNodeCursor.isNumericallyIndexed(n)) {
+                _nextToken = JsonToken.START_ARRAY;
+                _nodeCursor = new HoconNodeCursor.NumericallyIndexedObjectBackedArray(n, null);
+            } else {
+                _nextToken = JsonToken.START_OBJECT;
+                _nodeCursor = new HoconNodeCursor.Object(n, null);
+            }
         } else { // value node
             _nodeCursor = new HoconNodeCursor.RootValue(n, null);
         }
     }
     
     public static JsonToken asJsonToken(ConfigValue value) {
-		switch(value.valueType()) {
+        if (HoconNodeCursor.isNumericallyIndexed(value)) {
+            return JsonToken.START_ARRAY;
+        }
+        switch(value.valueType()) {
 			case BOOLEAN:
 				boolean bool = (Boolean) value.unwrapped();
 				return (bool) ? JsonToken.VALUE_TRUE 

--- a/src/test/java/com/jasonclawson/jackson/dataformat/hocon/TestArrays.java
+++ b/src/test/java/com/jasonclawson/jackson/dataformat/hocon/TestArrays.java
@@ -1,0 +1,47 @@
+package com.jasonclawson.jackson.dataformat.hocon;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+public class TestArrays {
+
+    private String hoconOne = "list = [\"a\", \"b\"]";
+    private String hoconTwo = "list.0 = \"a\"\nlist.2 = \"b\"";
+    private String hoconThree = "list = {\"2\" : \"b\", \"0\" : \"a\"}";
+
+    @Test
+    public void testArrays() throws IOException {
+        ObjectMapper mapper = new ObjectMapper(new HoconFactory());
+
+        System.out.println("Mapping hocon to Container class for:");
+        System.out.println(hoconOne);
+        Container cOne = mapper.readValue(hoconOne, Container.class);
+        System.out.println("The Container class's list value is " + cOne.list);
+
+        System.out.println("Mapping hocon to Container class for:");
+        System.out.println(hoconTwo);
+        Container cTwo = mapper.readValue(hoconTwo, Container.class);
+        System.out.println("The Container class's list value is " + cTwo.list);
+
+        System.out.println("Mapping hocon to Container class for:");
+        System.out.println(hoconThree);
+        Container cThree = mapper.readValue(hoconThree, Container.class);
+        System.out.println("The Container class's list value is " + cThree.list);
+
+        Assert.assertNotNull(cOne.list);
+        Assert.assertNotNull(cTwo.list);
+        Assert.assertNotNull(cThree.list);
+
+        Assert.assertEquals(cOne.list, cTwo.list);
+        Assert.assertEquals(cOne.list, cThree.list);
+        Assert.assertEquals(cThree.list, cTwo.list);
+    }
+
+    public static class Container {
+        public List<String> list;
+    }
+}


### PR DESCRIPTION
Per the [HOCON docs](https://github.com/typesafehub/config/blob/master/HOCON.md), Arrays should be lazily created from objects that have numerically indexed keys if the object cannot be mapped.

The following unit test should pass, but does not:

```
import com.fasterxml.jackson.databind.ObjectMapper;
import org.junit.Assert;
import org.junit.Test;

import java.io.IOException;
import java.util.List;

public class TestArrays {

    private String hoconOne = "list = [\"a\", \"b\"]";
    private String hoconTwo = "list.0 = \"a\"\nlist.2 = \"b\"";
    private String hoconThree = "list = {\"0\" : \"a\", \"2\" : \"b\"}";

    @Test
    public void testArrays() throws IOException {
        ObjectMapper mapper = new ObjectMapper(new HoconFactory());

        System.out.println("Mapping hocon of to Container class for:");
        System.out.println(hoconOne);
        Container cOne = mapper.readValue(hoconOne, Container.class);
        System.out.println("The Container class's list value is " + cOne.list);

        System.out.println("Mapping hocon of to Container class for:");
        System.out.println(hoconTwo);
        Container cTwo = mapper.readValue(hoconTwo, Container.class);
        System.out.println("The Container class's list value is " + cTwo.list);

        System.out.println("Mapping hocon of to Container class for:");
        System.out.println(hoconThree);
        Container cThree = mapper.readValue(hoconThree, Container.class);
        System.out.println("The Container class's list value is " + cThree.list);

        Assert.assertNotNull(cOne.list);
        Assert.assertNotNull(cTwo.list);
        Assert.assertNotNull(cThree.list);

        Assert.assertEquals(cOne.list, cTwo.list);
        Assert.assertEquals(cOne.list, cThree.list);
        Assert.assertEquals(cThree.list, cTwo.list);
    }

    public static class Container {
        public List<String> list;
    }
}
```

output:

```
Mapping hocon of to Container class for:
list = ["a", "b"]
The Container class's list value is [a, b]
Mapping hocon of to Container class for:
list.0 = "a"
list.2 = "b"

com.fasterxml.jackson.databind.JsonMappingException: Can not deserialize instance of java.util.ArrayList out of START_OBJECT token
 at [Source: N/A; line: -1, column: -1] (through reference chain: com.jasonclawson.jackson.dataformat.hocon.Container["list"])
    at com.fasterxml.jackson.databind.JsonMappingException.from(JsonMappingException.java:164)
    at com.fasterxml.jackson.databind.DeserializationContext.mappingException(DeserializationContext.java:691)
    at com.fasterxml.jackson.databind.DeserializationContext.mappingException(DeserializationContext.java:685)
    at com.fasterxml.jackson.databind.deser.std.StringCollectionDeserializer.handleNonArray(StringCollectionDeserializer.java:216)
    at com.fasterxml.jackson.databind.deser.std.StringCollectionDeserializer.deserialize(StringCollectionDeserializer.java:164)
    at com.fasterxml.jackson.databind.deser.std.StringCollectionDeserializer.deserialize(StringCollectionDeserializer.java:154)
    at com.fasterxml.jackson.databind.deser.std.StringCollectionDeserializer.deserialize(StringCollectionDeserializer.java:19)
    at com.fasterxml.jackson.databind.deser.SettableBeanProperty.deserialize(SettableBeanProperty.java:525)
    at com.fasterxml.jackson.databind.deser.impl.FieldProperty.deserializeAndSet(FieldProperty.java:106)
    at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:242)
    at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:118)
    at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:2986)
    at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:2091)
    at com.jasonclawson.jackson.dataformat.hocon.TestArrays.testArrays(TestArrays.java:26)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:45)
    at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:15)
    at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:42)
    at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:20)
    at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:263)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:68)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:47)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:231)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:60)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:229)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:50)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:222)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:300)
    at org.junit.runner.JUnitCore.run(JUnitCore.java:157)
    at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:74)
    at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:211)
    at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:67)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at com.intellij.rt.execution.application.AppMain.main(AppMain.java:134)


Process finished with exit code 255
```
