### PR TITLE
fixed casting problem with float fields

### DIFF
--- a/src/main/java/com/jasonclawson/jackson/dataformat/hocon/HoconTreeTraversingParser.java
+++ b/src/main/java/com/jasonclawson/jackson/dataformat/hocon/HoconTreeTraversingParser.java
@@ -327,34 +327,34 @@ public class HoconTreeTraversingParser extends ParserMinimalBase {
     @Override
     public BigInteger getBigIntegerValue() throws IOException, JsonParseException {
     	//I wish we could get at the string representation instead
-    	Long value = (Long) currentNumericNode().unwrapped();
+    	Long value = ((Number)  currentNumericNode().unwrapped()).longValue();
     	return BigInteger.valueOf(value);
     }
 
     @Override
     public BigDecimal getDecimalValue() throws IOException, JsonParseException {
-        Double value = (Double) currentNumericNode().unwrapped();
+        Double value = ((Number) currentNumericNode().unwrapped()).doubleValue();
     	return BigDecimal.valueOf(value);
     }
 
     @Override
     public double getDoubleValue() throws IOException, JsonParseException {
-        return (Double) currentNumericNode().unwrapped();
+        return ((Number) currentNumericNode().unwrapped()).doubleValue();
     }
 
     @Override
     public float getFloatValue() throws IOException, JsonParseException {
-        return (Float) currentNumericNode().unwrapped();
+        return ((Number) currentNumericNode().unwrapped()).floatValue();
     }
 
     @Override
     public long getLongValue() throws IOException, JsonParseException {
-        return (Long) currentNumericNode().unwrapped();
+        return ((Number) currentNumericNode().unwrapped()).longValue();
     }
 
     @Override
     public int getIntValue() throws IOException, JsonParseException {
-        return (Integer) currentNumericNode().unwrapped();
+        return ((Number) currentNumericNode().unwrapped()).intValue();
     }
 
     @Override

--- a/src/test/java/com/jasonclawson/jackson/dataformat/hocon/Configuration.java
+++ b/src/test/java/com/jasonclawson/jackson/dataformat/hocon/Configuration.java
@@ -7,6 +7,7 @@ public class Configuration {
 	
 		public String something;
 		public Context context;
+		public float value;
 		
 		public static class Context {
 			public Lib lib;

--- a/src/test/resources/com/jasonclawson/jackson/dataformat/hocon/test.conf
+++ b/src/test/resources/com/jasonclawson/jackson/dataformat/hocon/test.conf
@@ -1,5 +1,6 @@
 {
     something="This value comes from complex-app's complex2.conf"
+    value=2.0
 
     # here we want a simple-lib-context unique to our app
     # which can be custom-configured. In code, we have to


### PR DESCRIPTION
An object with a float field that had a value that could be an Integer
was failing to deserialize, due to an incorrect cast from Integer to
Float.
