### PR TITLE
Expose ConfigOrigin location information through JsonLocation and expose path information in parsing context.

### DIFF
--- a/src/main/java/com/jasonclawson/jackson/dataformat/hocon/HoconJsonLocation.java
+++ b/src/main/java/com/jasonclawson/jackson/dataformat/hocon/HoconJsonLocation.java
@@ -1,0 +1,48 @@
+package com.jasonclawson.jackson.dataformat.hocon;
+
+import java.net.URL;
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonLocation;
+import com.typesafe.config.ConfigOrigin;
+
+public class HoconJsonLocation extends JsonLocation implements ConfigOrigin {
+    private static final long serialVersionUID = 1L;
+    
+    private final ConfigOrigin origin;
+    
+    public HoconJsonLocation(final ConfigOrigin origin) {
+        super(origin.description(), -1L, origin.lineNumber(), -1);
+        this.origin = origin;
+    }
+
+    @Override
+    public String description() {
+        return origin.description();
+    }
+
+    @Override
+    public String filename() {
+        return origin.filename();
+    }
+
+    @Override
+    public URL url() {
+        return origin.url();
+    }
+
+    @Override
+    public String resource() {
+        return origin.resource();
+    }
+
+    @Override
+    public int lineNumber() {
+        return origin.lineNumber();
+    }
+
+    @Override
+    public List<String> comments() {
+        return origin.comments();
+    }
+}

--- a/src/main/java/com/jasonclawson/jackson/dataformat/hocon/HoconNodeCursor.java
+++ b/src/main/java/com/jasonclawson/jackson/dataformat/hocon/HoconNodeCursor.java
@@ -36,6 +36,25 @@ public abstract class HoconNodeCursor extends JsonStreamContext {
         _currentName = name;
     }
 	
+	/**
+     * HOCON specific method to construct the path for this node. Useful for
+     * interacting directly with the underlying Config instance in custom
+     * deserializers.
+     * 
+	 * @return The path of this node cursor.
+	 */
+	public String constructPath() {
+	    return constructPath(new StringBuilder()).toString();
+	}
+	
+	private StringBuilder constructPath(StringBuilder initial) {
+	    if (_parent != null) {
+	        return _parent.constructPath(initial).append('.').append(_currentName);
+	    } else {
+	        return initial.append(_currentName);
+	    }
+	}
+	
 	public abstract JsonToken nextToken();
 
     public abstract JsonToken endToken();

--- a/src/main/java/com/jasonclawson/jackson/dataformat/hocon/HoconNodeCursor.java
+++ b/src/main/java/com/jasonclawson/jackson/dataformat/hocon/HoconNodeCursor.java
@@ -36,24 +36,24 @@ public abstract class HoconNodeCursor extends JsonStreamContext {
         _currentName = name;
     }
 	
-	/**
+    /**
      * HOCON specific method to construct the path for this node. Useful for
      * interacting directly with the underlying Config instance in custom
      * deserializers.
      * 
-	 * @return The path of this node cursor.
-	 */
-	public String constructPath() {
-	    return constructPath(new StringBuilder()).toString();
-	}
+     * @return The path of this node cursor.
+     */
+    public String constructPath() {
+        return constructPath(new StringBuilder()).toString();
+    }
 	
-	private StringBuilder constructPath(StringBuilder initial) {
-	    if (_parent != null) {
-	        return _parent.constructPath(initial).append('.').append(_currentName);
-	    } else {
-	        return initial.append(_currentName);
-	    }
-	}
+    private StringBuilder constructPath(StringBuilder initial) {
+        if (_parent != null) {
+            return _parent.constructPath(initial).append('.').append(_currentName);
+        } else {
+            return initial.append(_currentName);
+        }
+    }
 	
 	public abstract JsonToken nextToken();
 

--- a/src/main/java/com/jasonclawson/jackson/dataformat/hocon/HoconTreeTraversingParser.java
+++ b/src/main/java/com/jasonclawson/jackson/dataformat/hocon/HoconTreeTraversingParser.java
@@ -58,6 +58,18 @@ public class HoconTreeTraversingParser extends ParserMinimalBase {
      */
     protected boolean _closed;
 
+    private final ConfigObject _rootObject;
+    
+    /**
+     * HOCON specific getter for the originating ConfigObject. Useful for
+     * accessing the underlying Config instance in custom deserializers.
+     * 
+     * @return The ConfigObject with which this parser was instantiated.
+     */
+    public ConfigObject getConfigObject() {
+        return _rootObject;
+    }
+    
     /*
     /**********************************************************
     /* Life-cycle
@@ -69,6 +81,7 @@ public class HoconTreeTraversingParser extends ParserMinimalBase {
     public HoconTreeTraversingParser(ConfigObject n, ObjectCodec codec)
     {
         super(0);
+        _rootObject = n;
         _objectCodec = codec;
         if (n.valueType() == ConfigValueType.LIST) {
             _nextToken = JsonToken.START_ARRAY;
@@ -243,12 +256,14 @@ public class HoconTreeTraversingParser extends ParserMinimalBase {
 
     @Override
     public JsonLocation getTokenLocation() {
-        return JsonLocation.NA;
+        final ConfigValue node = currentNode();
+        return node == null ? JsonLocation.NA : new HoconJsonLocation(node.origin());
     }
 
     @Override
     public JsonLocation getCurrentLocation() {
-        return JsonLocation.NA;
+        final ConfigValue node = currentNode();
+        return node == null ? JsonLocation.NA : new HoconJsonLocation(node.origin());
     }
 
     /*


### PR DESCRIPTION
This PR implements the `getTokenLocation()` methods on `HoconTreeTraversingParser ` as described in #4. This is useful for error reporting.

Additionally, it creates a way to access the underlying `ConfigObject` of a parser and to construct the path information for a `HoconNodeCursor`. These can be used in custom (de)serializers where Typesafe Config functionality is desired. See this example for deserializing a string into a `java.util.Duration` instance using `Config#getDuration(...)`.

```java
public class MyDurationDeserializer extends StdScalarDeserializer<Duration> {
    public MyDurationDeserializer() {
        super(Duration.class);
    }

    @Override
    public Duration deserialize(JsonParser p, DeserializationContext ctx) throws IOException, JsonProcessingException {
        if (!(p instanceof HoconTreeTraversingParser)) {
            throw ctx.mappingException("Duration deserialization only available when using HOCON parser.");
        } else if (VALUE_STRING == p.getCurrentToken()) {
            try {
                final HoconTreeTraversingParser hoconParser = (HoconTreeTraversingParser) p;
                final HoconNodeCursor cursor = (HoconNodeCursor) p.getParsingContext();
                final long millis = hoconParser.getConfigObject().toConfig().getDuration(cursor.constructPath(), TimeUnit.MILLISECONDS);
                return Duration.ofMillis(millis);
            } catch(ConfigException ce) {
                throw ctx.mappingException("Could not parse duration from value: '" + p.getText() + "'.");
            }
        } else {
            throw ctx.mappingException("Expected string value for Duration mapping.");
        }
    }
}
```

Because of the addition of the location information, when parsing fails, you get an exception with information about the source location of the failure:

```
Exception in thread "main" com.fasterxml.jackson.databind.JsonMappingException: Could not parse duration from value: '42 leap years'.
 at [Source: mapping-test.conf: 3; line: 3, column: -1]
	at com.fasterxml.jackson.databind.JsonMappingException.from(JsonMappingException.java:148)
	at com.fasterxml.jackson.databind.DeserializationContext.mappingException(DeserializationContext.java:843)
	at io.divolte.server.JacksonHoconTest$MyDurationDeserializer.deserialize(JacksonHoconTest.java:150)
	at io.divolte.server.JacksonHoconTest$MyDurationDeserializer.deserialize(JacksonHoconTest.java:1)
	at com.fasterxml.jackson.databind.deser.SettableBeanProperty.deserialize(SettableBeanProperty.java:523)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeUsingPropertyBased(BeanDeserializer.java:381)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromObjectUsingNonDefault(BeanDeserializerBase.java:1073)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:295)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:142)
	at com.fasterxml.jackson.databind.deser.SettableBeanProperty.deserialize(SettableBeanProperty.java:523)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeUsingPropertyBased(BeanDeserializer.java:381)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromObjectUsingNonDefault(BeanDeserializerBase.java:1073)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:295)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:142)
	at com.fasterxml.jackson.databind.ObjectMapper._readValue(ObjectMapper.java:3534)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:1870)
	at io.divolte.server.JacksonHoconTest.main(JacksonHoconTest.java:54)
```