### PR TITLE
Introduce additional checks that promote hocon maps to json arrays.

### DIFF
--- a/src/main/java/com/jasonclawson/jackson/dataformat/hocon/HoconNodeCursor.java
+++ b/src/main/java/com/jasonclawson/jackson/dataformat/hocon/HoconNodeCursor.java
@@ -1,5 +1,6 @@
 package com.jasonclawson.jackson.dataformat.hocon;
 
+import java.util.BitSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.TreeMap;
@@ -105,9 +106,20 @@ public abstract class HoconNodeCursor extends JsonStreamContext {
                 if (map.isEmpty()) {
                     return false;
                 }
+                // Because TypeSafe config does not preserve types of keys 
+                // we have to revert to heuristics to detect if it was originally an array
+                // two conditions are verified:
+                // 1. all keys must be non-negative integers
+                // 2. all keys must form a consecutive set of integers starting from 0
+                int size = map.size();
                 for (String key : map.keySet()) {
                     try {
-                        Integer.parseInt(key);
+                        int idx = Integer.parseInt(key);
+                        if (idx < 0) {
+                            return false;
+                        } else if (idx >= size) {
+                            return false;
+                        }
                     } catch (NumberFormatException e) {
                         return false;
                     }

--- a/src/main/java/com/jasonclawson/jackson/dataformat/hocon/HoconNodeCursor.java
+++ b/src/main/java/com/jasonclawson/jackson/dataformat/hocon/HoconNodeCursor.java
@@ -1,6 +1,5 @@
 package com.jasonclawson.jackson.dataformat.hocon;
 
-import java.util.BitSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.TreeMap;
@@ -110,7 +109,7 @@ public abstract class HoconNodeCursor extends JsonStreamContext {
                 // we have to revert to heuristics to detect if it was originally an array
                 // two conditions are verified:
                 // 1. all keys must be non-negative integers
-                // 2. all keys must form a consecutive set of integers starting from 0
+                // 2. all keys must form a consecutive set of integers 0..N-1 where N is size of map
                 int size = map.size();
                 for (String key : map.keySet()) {
                     try {

--- a/src/test/java/com/jasonclawson/jackson/dataformat/hocon/TestArrays.java
+++ b/src/test/java/com/jasonclawson/jackson/dataformat/hocon/TestArrays.java
@@ -1,17 +1,23 @@
 package com.jasonclawson.jackson.dataformat.hocon;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 public class TestArrays {
 
     private String hoconOne = "list = [\"a\", \"b\"]";
-    private String hoconTwo = "list.0 = \"a\"\nlist.2 = \"b\"";
-    private String hoconThree = "list = {\"2\" : \"b\", \"0\" : \"a\"}";
+    private String hoconTwo = "list.0 = \"a\"\nlist.1 = \"b\"";
+    private String hoconThree = "list = {\"1\" : \"b\", \"0\" : \"a\"}";
 
     @Test
     public void testArrays() throws IOException {
@@ -40,8 +46,76 @@ public class TestArrays {
         Assert.assertEquals(cOne.list, cThree.list);
         Assert.assertEquals(cThree.list, cTwo.list);
     }
+    
+    @Test
+    public void testNonArray() throws JsonProcessingException, IOException {
+        testNonArray("{ \"-1\" : \"A\" }");
+        testNonArray("{ \"1\" : \"A\" }");
+        testNonArray("{ }");
+    }
+    
+    private void testNonArray(String json) throws JsonProcessingException, IOException {
+        ObjectMapper hoconmapper = new ObjectMapper(new HoconFactory());
+        JsonNode node = hoconmapper.readTree(json);
+        assertFalse("Should NOT be resolved to array :"+json, node.isArray());
+    }
+
+    @Test
+    public void testSymmetry() throws IOException {
+        doTestSymmetry();
+        doTestSymmetry("A");
+        doTestSymmetry("A", "B");
+        doTestSymmetry("A", null);
+        doTestSymmetry(null, "B");
+        doTestSymmetry(null, null);
+    }
+
+
+    private void doTestSymmetry(String... values) throws IOException {
+        List<String> list = new ArrayList<String>();
+        for (String s : values) {
+            list.add(s);
+        }
+        // TODO use hocon mapper for writes when available
+        ObjectMapper jsonmapper = new ObjectMapper();
+        ObjectMapper hoconmapper = new ObjectMapper(new HoconFactory());
+        Container c1 = new Container();
+        c1.list = list;
+        
+        String json = jsonmapper.writeValueAsString(c1);
+        System.out.println(list + " => " + json);
+        Container c2 = hoconmapper.readValue(json, Container.class);
+        
+        assertEquals(c1,c2);
+    }
+
 
     public static class Container {
         public List<String> list;
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + ((list == null) ? 0 : list.hashCode());
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            Container other = (Container) obj;
+            if (list == null) {
+                if (other.list != null)
+                    return false;
+            } else if (!list.equals(other.list))
+                return false;
+            return true;
+        }
     }
 }


### PR DESCRIPTION
In addition to being a valid integer keys must also form a consecutive 0..N-1 set of numbers (N being size of map).
Previous implementation was treating any map with integer keys as arrays, not forcing them to be consecutive and effectively
prohibiting actual maps of some keys that look like integers to be maps.

The workaround for map

{ "1" : "A" , "5" : "B" }

was to introduce artifical non-integer key .

After this change, such map is no loneger treated like array because it has only elements on indices 1,5 not forming a consecutive range 0,1

The rationale behind this change is that this is hocon-json bridge not pure hocon config. Thus it is typically
used in scenarios where there was a json processing already in place and move to hocon is driven by it features like optional commas, multiline string, etc.
however max compliancy with json is required.
Existing json structures still may relay on arrays and maps and they will fail when maps are unexpectedly converted to arrays.